### PR TITLE
feat: automatically adds issues/PRs to Cloud Team board

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,21 @@
+# Automatically assigns new issues
+# to the Cloud Team project
+# https://github.com/orgs/WalletConnect/projects/9
+name: assign
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    name: Add issue to Cloud Team
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.1.0
+        with:
+          project-url: https://github.com/orgs/WalletConnect/projects/9
+          github-token: ${{ secrets.ASSIGN_TO_PROJECT_GITHUB_TOKEN }}
+


### PR DESCRIPTION
# Changes

We use this in other projects, too e.g. https://github.com/WalletConnect/ts-relay/pull/198

This allows the team to track ops PRs/issues through the team board.

## Changes Tested

Copied from https://github.com/WalletConnect/ops/pull/182
