### PR TITLE
fix: GoTrue Emails

### DIFF
--- a/email-templates/confirm-signup.html
+++ b/email-templates/confirm-signup.html
@@ -107,7 +107,7 @@
           <tr>
             <td align="center" valign="top" style="padding: 36px 24px;">
               <a href="https://walletconnect.com" target="_blank" style="display: inline-block;">
-                <img src="https://raw.githubusercontent.com/WalletConnect/walletconnect-assets/master/png/original/walletconnect-banner.png" alt="Logo" border="0" width="250" style="display: block; width: 250px; max-width: 250px; min-width: 250px;">
+                <img src="https://raw.githubusercontent.com/WalletConnect/walletconnect-assets/master/Lockup/Blue%20(Default)/Lockup.png" alt="Logo" border="0" width="250" style="display: block; width: 250px; max-width: 250px; min-width: 250px;">
               </a>
             </td>
           </tr>

--- a/email-templates/reset-password.html
+++ b/email-templates/reset-password.html
@@ -107,7 +107,7 @@
           <tr>
             <td align="center" valign="top" style="padding: 36px 24px;">
               <a href="https://walletconnect.com" target="_blank" style="display: inline-block;">
-                <img src="https://raw.githubusercontent.com/WalletConnect/walletconnect-assets/master/png/original/walletconnect-banner.png" alt="Logo" border="0" width="250" style="display: block; width: 250px; max-width: 250px; min-width: 250px;">
+                <img src="https://raw.githubusercontent.com/WalletConnect/walletconnect-assets/master/Lockup/Blue%20(Default)/Lockup.png" alt="Logo" border="0" width="250" style="display: block; width: 250px; max-width: 250px; min-width: 250px;">
               </a>
             </td>
           </tr>

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -79,7 +79,7 @@ resource "aws_ecs_task_definition" "app_task_definition" {
         },
         {
           name  = "API_EXTERNAL_URL",
-          value = "https://${var.subdomain != null ? "${var.subdomain}." : ""}${var.fqdn}"
+          value = "https://${var.subdomain != null ? "${var.subdomain}." : ""}${var.fqdn}/auth/v1"
         },
         {
           name  = "GOTRUE_MAILER_SUBJECTS_RECOVERY",

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -86,16 +86,24 @@ resource "aws_ecs_task_definition" "app_task_definition" {
           value = "Reset Your WalletConnect Password"
         },
         {
+          name = "GOTRUE_MAILER_URLPATHS_RECOVERY",
+          value = "/auth/v1/verify"
+        },
+        {
           name  = "GOTRUE_MAILER_TEMPLATES_RECOVERY",
-          value = var.reset_password_email
+          value = "https://raw.githubusercontent.com/WalletConnect/CloudSIWE/main/email-templates/reset-password.html"
         },
         {
           name  = "GOTRUE_MAILER_SUBJECTS_CONFIRMATION",
           value = "Confirm Your WalletConnect Signup"
         },
         {
+          name = "GOTRUE_MAILER_URLPATHS_CONFIRMATION",
+          value = "/auth/v1/verify"
+        },
+        {
           name  = "GOTRUE_MAILER_TEMPLATES_CONFIRMATION",
-          value = var.confirm_signup_email
+          value = "https://raw.githubusercontent.com/WalletConnect/CloudSIWE/main/email-templates/confirm-signup.html"
         }
       ],
       logConfiguration = {

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -86,7 +86,7 @@ resource "aws_ecs_task_definition" "app_task_definition" {
           value = "Reset Your WalletConnect Password"
         },
         {
-          name = "GOTRUE_MAILER_URLPATHS_RECOVERY",
+          name  = "GOTRUE_MAILER_URLPATHS_RECOVERY",
           value = "/auth/v1/verify"
         },
         {
@@ -98,7 +98,7 @@ resource "aws_ecs_task_definition" "app_task_definition" {
           value = "Confirm Your WalletConnect Signup"
         },
         {
-          name = "GOTRUE_MAILER_URLPATHS_CONFIRMATION",
+          name  = "GOTRUE_MAILER_URLPATHS_CONFIRMATION",
           value = "/auth/v1/verify"
         },
         {

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -124,11 +124,3 @@ variable "supabase_url" {
 variable "cors_origins" {
   type = string
 }
-
-variable "confirm_signup_email" {
-  type = string
-}
-
-variable "reset_password_email" {
-  type = string
-}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -87,9 +87,6 @@ module "ecs" {
 
   supabase_url = var.supabase_url
   cors_origins = var.cors_origins
-
-  confirm_signup_email = file("../email-templates/confirm-signup.html")
-  reset_password_email = file("../email-templates/reset-password.html")
 }
 
 data "aws_ecr_repository" "gotrue" {


### PR DESCRIPTION
# Changes
- GoTrue Emails are now as before
- Email can be verified again
- Repo is public 🎉 

## Changes Tested

- [x] Ran `terraform -chdir=terraform apply  -var-file="vars/dev.tfvars"` locally
